### PR TITLE
chore(redesign): simplified  abstraction and made it consistent 

### DIFF
--- a/examples/select.example.ts
+++ b/examples/select.example.ts
@@ -1,0 +1,18 @@
+import { useData } from '../src'
+
+(() => {
+  const [record, { select }] = useData({ attributes: { status: 'idle', info: 'initial value' }})
+ 
+  const [attributes, { update }] = select(record => record.attributes)
+
+  update((attributes) => {
+    attributes.status = 'successful'
+    attributes.info = 'some value...'
+  })
+
+  // after update is rendered
+  record.attributes.status === 'successful'
+  record.attributes.info === 'some value...'
+  attributes.status === 'successful'
+  attributes.info = 'some value...'
+})()

--- a/examples/update.example.ts
+++ b/examples/update.example.ts
@@ -1,0 +1,14 @@
+import { useData } from '../src'
+
+(() => {
+  const [record, { update }] = useData({ attributes: { status: 'idle', info: 'initial value' }})
+ 
+  update((record) => {
+    record.attributes.status = 'successful'
+    record.attributes.info = 'some value...'
+  })
+
+    // after update is rendered
+    record.attributes.status === 'successful'
+    record.attributes.info === 'some value...'
+})()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drifting",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A fully typescript typed react solution for interacting with complex data-structures",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drifting",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A fully typescript typed react solution for interacting with complex data-structures",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "yarn jest",
     "test:watch": "yarn jest --watchAll",
-    "build": "rimraf ./lib && tsc"
+    "build": "rimraf ./lib && tsc",
+    "build:watch": "rimraf ./lib && tsc --watch true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drifting",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A fully typescript typed react solution for interacting with complex data-structures",
   "main": "lib/index.js",
   "scripts": {

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -181,14 +181,11 @@ describe('useData', () => {
       }
     
       const { result } = renderHook(() => useData(rec))
-      const [, ctr] = result.current
-           // @ts-ignore
-      const [, attrCtrl] = ctr.select((record) => record.attributes)
-              // @ts-ignore
+      const [, ctrl] = result.current
+      const [, attrCtrl] = ctrl.select((record) => record.attributes)
       const [, infoCtrl] = attrCtrl.select((attributes) => attributes.info)
   
       act(() => {
-                // @ts-ignore
         infoCtrl.update(info => {
           info.status = 'offline'
         })

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from '@testing-library/react-hooks'
-
+import { act, renderHook } from '@testing-library/react-hooks'
 import { useData } from '..'
+
 
 const record = {
   type: 'user',

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -86,15 +86,26 @@ describe('useData', () => {
   
     
     it('should update entire obj when using return', () => {
-      const { result } = renderHook(() => useData(record))
+      const data = {
+        replace: {
+          type: 'item',
+          id: 'not-replaced'
+        }
+      }
+
+      const { result } = renderHook(() => useData(data))
   
       act(() => {
         const [, controller] = result.current
   
-        controller.update(user => ({ id: 'replaced', type: user.type }))
+        controller.update(data => ({
+          replace: { 
+            id: 'replaced', type: data.replace.type 
+          }
+        }))
       })
   
-      expect(result.current[0]).toEqual({ id: 'replaced', type: 'user' })
+      expect(result.current[0]).toEqual({ replace: { id: 'replaced', type: 'item' } })
     })
   
     it('should apply changes to new object', () => {

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -40,460 +40,162 @@ const record = {
 } 
 
 describe('useData', () => {
-  it('should update properties', () => {
-    const { result } = renderHook(() => useData(record))
-
-    act(() => {
-      result.current[1].draft((user) => {
-        user.attributes = { name: 'independent', company: 'defiance' }
-      })
-    })
-
-    expect(result.current[0].attributes)
-    .toEqual({ name: 'independent', company: 'defiance' })
-  })
-
-  it('should allow multiple property updates', () => {
-    const { result } = renderHook(() => useData(record))
-
-    act(() => {
-      const [, controller] = result.current
-
-      controller.draft(user => {
-        user.attributes.name = 'new-name'
-        user.relationships.revision.attributes.name = 'new-name'
-      })
-    })
-
-    expect(result.current[0].attributes.name).toBe('new-name')
-    expect(result.current[0].relationships.revision.attributes.name).toBe('new-name')
-  })
-
-  it('should update deeply nested properties', () => {
-    const { result } = renderHook(() => useData(record))
-
-    act(() => {
-      const [, controller] = result.current
-
-      controller.draft(user => {
-        user.relationships.budgets[0].attributes.threshold = 14
-      })
-    })
-
-    expect(result.current[0].relationships.budgets[0].attributes.threshold).toBe(14)
-  })
-
+  describe('update', () => {
+    it('should update properties', () => {
+      const { result } = renderHook(() => useData(record))
   
-  it('should update entire obj when using return', () => {
-    const { result } = renderHook(() => useData(record))
-
-    act(() => {
-      const [, controller] = result.current
-
-      controller.draft(user => ({ id: 'replaced', type: user.type }))
-    })
-
-    expect(result.current[0]).toEqual({ id: 'replaced', type: 'user' })
-  })
-
-  it('should apply changes to new object', () => {
-    const reference = { id: '10', type: 'budget' , attributes: { name: 'test' } }
-    const { result } = renderHook(() => useData(reference))
- 
-    act(() => {
-      const [, controller] = result.current
-
-      controller.draft(user => {
-        user.attributes.name = 'new-name'
-      })
-    })
-
-    expect(result.current[0] === reference).toBe(false)
-    expect(result.current[0]).toEqual({ 
-      id: '10', 
-      type: 'budget', 
-      attributes: { name: 'new-name' } 
-    })
-    expect(reference).toEqual({
-      id: '10', 
-      type: 'budget', 
-      attributes: { name: 'test' } 
-    })
-  })
-
-  it('should work with collections', () => {
-    const collection = [
-      { type: 'budget', id: '1' }
-    ]
-    const { result } = renderHook(() => useData(collection))
- 
-    act(() => {
-      const [, controller] = result.current
-
-      controller.draft(collection => {
-        collection.push({ type: 'budget', id: '2' })
-      })
-    })
-
-    expect(result.current[0]).toEqual([
-      { type: 'budget', id: '1' },
-      { type: 'budget', id: '2' },
-    ])
-
-  })
-
-  describe('entity - general', () => {
-    it('should be able to use multiple entity performers', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' }
-        ],
-        anotherCollection: [
-          { type: 'revision', id: '1' }
-        ]
-      }
-
-      const { result } = renderHook(() => useData(record))
-
       act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .add({ type: 'budget', id: '2' })
-
-          controller.entity(user.anotherCollection)
-            .add({ type: 'revision', id: '2' })
+        result.current[1].update((user) => {
+          user.attributes = { name: 'independent', company: 'defiance' }
         })
       })
-
-      expect(result.current[0].collection)
-      .toEqual([
-        { type: 'budget', id: '1' },
-        { type: 'budget', id: '2' }
-      ])
-      expect(result.current[0].anotherCollection)
-      .toEqual([
-        { type: 'revision', id: '1' },
-        { type: 'revision', id: '2' }
-      ])
+  
+      expect(result.current[0].attributes)
+      .toEqual({ name: 'independent', company: 'defiance' })
     })
-
-    it('should be able to chain operations', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' },
-          { type: 'budget', id: '2' }
-        ]
-      }
-      
+  
+    it('should allow multiple property updates', () => {
       const { result } = renderHook(() => useData(record))
-
+  
       act(() => {
         const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .remove(
-              (record) => record.id === '1',
-              (record) => record.id === '2',
-            )
-            .add({ type: 'budget', id: '2' })
-            .select(record => record.id === '2')
-            .replace({ type: 'budget', id: '5' })
-            .draft(budget => {
-              budget.type = 'user'
-            })
+  
+        controller.update(user => {
+          user.attributes.name = 'new-name'
+          user.relationships.revision.attributes.name = 'new-name'
         })
       })
-
-      expect(result.current[0].collection).toEqual([{ type: 'user', id: '5' }])
+  
+      expect(result.current[0].attributes.name).toBe('new-name')
+      expect(result.current[0].relationships.revision.attributes.name).toBe('new-name')
     })
-  })
-
-  describe('entity - record operations', () => {
-    it('should be able to replace entire record', () => {
-      const record = {
-        user: {
-          type: 'user',
-          id: '1',
-          name: 'Michiel'
-        }
-      }
-      
+  
+    it('should update deeply nested properties', () => {
       const { result } = renderHook(() => useData(record))
-
+  
       act(() => {
         const [, controller] = result.current
-
-        controller.draft(record => {
-          controller.entity(record.user)
-            .replace({ type: 'user', id: '4', name: 'Exivity' })
+  
+        controller.update(user => {
+          user.relationships.budgets[0].attributes.threshold = 14
         })
       })
-
-      expect(result.current[0].user).toEqual({ type: 'user', id: '4', name: 'Exivity' })
+  
+      expect(result.current[0].relationships.budgets[0].attributes.threshold).toBe(14)
     })
-
-    it('should be able to draft updates', () => {
-      const record = {
-        user: {
-          type: 'user',
-          id: '1',
-          name: 'Michiel'
-        }
-      }
-      
+  
+    
+    it('should update entire obj when using return', () => {
       const { result } = renderHook(() => useData(record))
-
+  
       act(() => {
         const [, controller] = result.current
-
-        controller.draft(record => {
-          controller.entity(record.user)
-            .draft(user => void (user.name = 'Exivity', user.id = '4'))
-        })
+  
+        controller.update(user => ({ id: 'replaced', type: user.type }))
       })
-
-      expect(result.current[0].user).toEqual({ type: 'user', id: '4', name: 'Exivity' })
+  
+      expect(result.current[0]).toEqual({ id: 'replaced', type: 'user' })
     })
-  })
-
-  describe('entity - collection operations', () => {
-    it('should be able to add', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' }
-        ]
-      }
-
-      const { result } = renderHook(() => useData(record))
-
+  
+    it('should apply changes to new object', () => {
+      const reference = { id: '10', type: 'budget' , attributes: { name: 'test' } }
+      const { result } = renderHook(() => useData(reference))
+   
       act(() => {
         const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .add({ type: 'budget', id: '2' })
+  
+        controller.update(user => {
+          user.attributes.name = 'new-name'
         })
       })
-
-      expect(result.current[0].collection).toEqual([
-        { type: 'budget', id: '1' },
-        { type: 'budget', id: '2' }
-      ])
+  
+      expect(result.current[0] === reference).toBe(false)
+      expect(result.current[0]).toEqual({ 
+        id: '10', 
+        type: 'budget', 
+        attributes: { name: 'new-name' } 
+      })
+      expect(reference).toEqual({
+        id: '10', 
+        type: 'budget', 
+        attributes: { name: 'test' } 
+      })
     })
-
-    it('should be able to add multiple', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' }
-        ]
-      }
-
-      const { result } = renderHook(() => useData(record))
-
+  
+    it('should work with collections', () => {
+      const collection = [
+        { type: 'budget', id: '1' }
+      ]
+      const { result } = renderHook(() => useData(collection))
+   
       act(() => {
         const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .add(
-              { type: 'budget', id: '2' },
-              { type: 'budget', id: '3' }
-            )
+  
+        controller.update(collection => {
+          collection.push({ type: 'budget', id: '2' })
         })
       })
-
-      expect(result.current[0].collection).toEqual([
+  
+      expect(result.current[0]).toEqual([
         { type: 'budget', id: '1' },
         { type: 'budget', id: '2' },
-        { type: 'budget', id: '3' }
-      ])
-    })
-
-    it('should be able to remove', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' }
-        ]
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .remove((record) => record.id === '1')
-        })
-      })
-
-      expect(result.current[0].collection).toEqual([])
-    })
-
-    it('should be able to remove multiple', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' },
-          { type: 'budget', id: '2' }
-        ]
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .remove((record) => record.type === 'budget')
-        })
-      })
-
-      expect(result.current[0].collection).toEqual([])
-    })
-
-    it('should be able to remove with multiple predicates', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1' },
-          { type: 'budget', id: '2' }
-        ]
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .remove(
-              (record) => record.id === '1',
-              (record) => record.id === '2',
-            )
-        })
-      })
-
-      expect(result.current[0].collection).toEqual([])
-    })
-
-    it('should be able to select from array and perform RecordOperations on it', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1', name: 'one' },
-          { type: 'budget', id: '2', name: 'two' }
-        ]
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .select((budget) => budget.id === '1')
-            .replace({ type: 'budget', id: '4', name: 'one'})
-            .draft(budget => {
-              budget.name = 'altered'
-            })
-        })
-      })
-
-      expect(result.current[0].collection).toEqual([
-        { type: 'budget', id: '4', name: 'altered' },
-        { type: 'budget', id: '2', name: 'two' }
-      ])
-    })
-
-    it('shouldnt break if select gets undefined result', () => {
-      const record = {
-        collection: [
-          { type: 'budget', id: '1', name: 'one' },
-          { type: 'budget', id: '2', name: 'two' }
-        ]
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-
-        controller.draft(user => {
-          controller.entity(user.collection)
-            .select((budget) => budget.id === '5')
-            .replace({ type: 'budget', id: '4', name: 'one' })
-            .draft(budget => {
-              budget.name = 'altered'
-            })
-        })
-      })
-
-      expect(result.current[0].collection).toEqual([
-        { type: 'budget', id: '1', name: 'one' },
-        { type: 'budget', id: '2', name: 'two' }
       ])
     })
   })
 
-  describe('entity - selectors', () => {
-    it('should be able to use a selector for a record', () => {
-      const record = {
-        user: {
-          id: '10',
-          type: 'user'
+  describe('select', () => {
+    it('should be possible to narrow the state and state controller while maintaining it as a single state', () => {
+      const rec = { 
+        type: 'budget' , 
+        attributes: { 
+          name: 'test'
         }
       }
-      
-      const { result } = renderHook(() => useData(record))
-
+    
+      const { result } = renderHook(() => useData(rec))
+      const [, ctr] = result.current
+   
+              // @ts-ignore
+      const [, attrCtrl] = ctr.select((record) => record.attributes)
+  
       act(() => {
-        const [, controller] = result.current
-        const recordUser = controller.sliceEntity(record => record.user)
-       
-        recordUser(operator => operator.draft((user) => {
-          user.id = 'altered'
-        }))
-      })
-
-      expect(result.current[0].user).toEqual({ 
-        type: 'user', 
-        id: 'altered'
-      })
-    })
-
-    it('should be able to use a selector for a collection', () => {
-      const record = {
-        user: {
-          collection: [
-            { type: 'budget', id: '1', name: 'one' },
-            { type: 'budget', id: '2', name: 'two' }
-          ]
-        }
-      }
-      
-      const { result } = renderHook(() => useData(record))
-
-      act(() => {
-        const [, controller] = result.current
-        const recordUserCollection = controller.sliceEntity(record => record.user.collection)
-
-        recordUserCollection((operator) => {
-          operator
-            .select((budget) => budget.id === '1')
-            .draft(budget => {
-              budget.name = 'altered'
-            })
+        // @ts-ignore
+        attrCtrl.update(attributes => {
+          attributes.name = 'updated'
         })
       })
+  
+      const record = result.current[0]
+      expect(record.attributes.name).toBe('updated')
+    })
 
-      expect(result.current[0].user.collection).toEqual([
-        { type: 'budget', id: '1', name: 'altered' },
-        { type: 'budget', id: '2', name: 'two' }
-      ])
+    it('should be possible to narrow the state and state controller recursively', () => {
+      const rec = { 
+        type: 'budget' , 
+        attributes: { 
+          name: 'test',
+          info: {
+            status: 'online'
+          }
+        }
+      }
+    
+      const { result } = renderHook(() => useData(rec))
+      const [, ctr] = result.current
+           // @ts-ignore
+      const [, attrCtrl] = ctr.select((record) => record.attributes)
+              // @ts-ignore
+      const [, infoCtrl] = attrCtrl.select((attributes) => attributes.info)
+  
+      act(() => {
+                // @ts-ignore
+        infoCtrl.update(info => {
+          info.status = 'offline'
+        })
+      })
+  
+      const record = result.current[0]
+      expect(record.attributes.info.status).toBe('offline')
     })
   })
 })

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -202,5 +202,30 @@ describe('useData', () => {
       const record = result.current[0]
       expect(record.attributes.info.status).toBe('offline')
     })
+
+    it('should be possible to return a new slice when using select', () => {
+      const rec = { 
+        type: 'budget' , 
+        attributes: { 
+          name: 'test',
+          info: {
+            status: 'online'
+          }
+        }
+      }
+    
+      const { result } = renderHook(() => useData(rec))
+      const [, ctrl] = result.current
+      const [, attrCtrl] = ctrl.select((record) => record.attributes)
+      const [, infoCtrl] = attrCtrl.select((attributes) => attributes.info)
+  
+      act(() => {
+        infoCtrl.update(() => ({ status: 'offline' }))
+      })
+  
+      const record = result.current[0]
+
+      expect(record.attributes.info.status).toBe('offline')
+    })
   })
 })

--- a/src/__tests__/useData.ts
+++ b/src/__tests__/useData.ts
@@ -153,13 +153,10 @@ describe('useData', () => {
       }
     
       const { result } = renderHook(() => useData(rec))
-      const [, ctr] = result.current
-   
-              // @ts-ignore
-      const [, attrCtrl] = ctr.select((record) => record.attributes)
+      const [, ctrl] = result.current
+      const [, attrCtrl] = ctrl.select((record) => record.attributes)
   
       act(() => {
-        // @ts-ignore
         attrCtrl.update(attributes => {
           attributes.name = 'updated'
         })

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from 'react'
 import produce, { Draft } from 'immer'
+import { useEffect, useMemo, useState } from 'react'
 
 type AnyFunction = (...args: any[]) => any
 
@@ -24,21 +24,18 @@ function createReturnedTuple<G> (nextDataState: G, updateFn: (cb: UpdateCb<G>) =
        * @description 
        * Use .update() to make mutations, like with immer, to your data structure. 
        * @example 
-       * const [record, { update }] useData(data)
-       * 
-       * update((record) => {
-       *   record.attributes.status = 'successful'
-       *   record.attributes.info = 'some value...'
-       * })
+       * ```typescript
+       * [[include:update.example.ts]]
+       * ```
       */
         update,
       /**
        * @description 
        * Narrow down the state and updater by using .select()
        * @example 
-       * const [record, { select }] useData(data)
-       * 
-       * const [attributes, { update }] = select(record => record.atributes)
+       * ```typescript
+       * [[include:select.example.ts]]
+       * ```
       */
         select: createReturnedTuple<Slice<T>>(selectedDataState, update)
       }

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -34,9 +34,10 @@ export function useData<T extends Data = Record<string, unknown>> (data: T) {
   }, [data])
 
   return useMemo(() => {
-    return createReturnedTuple(nextDataState, (updater) => {
-      setDataState(produce(nextDataState, updater) as T)
-    })(data => data)
+    return createReturnedTuple(
+      nextDataState, 
+      (updater) => void (setDataState(produce(nextDataState, updater) as T))
+    )(data => data)
   }, [nextDataState])
 }
 

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -14,7 +14,7 @@ function createReturnedTuple<G> (nextState: G, updateFn: (cb: UpdateCb<G>) => vo
     const slicedNextState: Slice<T> = getSelected(nextState)
 
     const update = (updateSelected: UpdateCb<Slice<T>>) => (
-      updateFn((proxy) => updateSelected(getSelected(proxy as G)))
+      updateFn((draft) => updateSelected(getSelected(draft as G)))
     )
 
     return [

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -40,4 +40,3 @@ export function useData<T extends Data = Record<string, unknown>> (data: T) {
     )(data => data)
   }, [nextDataState])
 }
-

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -9,13 +9,23 @@ type Slice<T extends AnyFunction> = T extends (...args: any[]) => infer R
 
 type UpdateCb<G> = (args: Draft<G>) => G|void|undefined
 
+function copy<T extends Record<string, any>> (obj1: T, obj2: T) {
+  for (let key in obj1) {
+    obj1[key] = obj2[key]
+  }
+}
+
 function createReturnedTuple<G> (nextDataState: G, updateFn: (cb: UpdateCb<G>) => void) {
   return <T extends (slice: G) => any>(getSelected: T) => {
     const selectedDataState: Slice<T> = getSelected(nextDataState)
 
-    const update = (updateSelected: UpdateCb<Slice<T>>) => (
-      updateFn((draft) => updateSelected(getSelected(draft as G)))
-    )
+    const update = (updateSelected: UpdateCb<Slice<T>>) => updateFn((draft) => {
+       const result = updateSelected(getSelected(draft as G))
+
+       if (result) {
+          copy(getSelected(draft as G), result)
+       }
+    })
 
     return [
       selectedDataState,

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -20,11 +20,12 @@ function createReturnedTuple<G> (nextDataState: G, updateFn: (cb: UpdateCb<G>) =
     const selectedDataState: Slice<T> = getSelected(nextDataState)
 
     const update = (updateSelected: UpdateCb<Slice<T>>) => updateFn((draft) => {
-       const result = updateSelected(getSelected(draft as G))
+      const selectedDraft = getSelected(draft as G)
+      const result = updateSelected(selectedDraft)
 
-       if (result) {
-          copy(getSelected(draft as G), result)
-       }
+      if (result) {
+        copy(selectedDraft, result)
+      }
     })
 
     return [

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -9,19 +9,38 @@ type Slice<T extends AnyFunction> = T extends (...args: any[]) => infer R
 
 type UpdateCb<G> = (args: Draft<G>) => G|void|undefined
 
-function createReturnedTuple<G> (nextState: G, updateFn: (cb: UpdateCb<G>) => void) {
+function createReturnedTuple<G> (nextDataState: G, updateFn: (cb: UpdateCb<G>) => void) {
   return <T extends (slice: G) => any>(getSelected: T) => {
-    const slicedNextState: Slice<T> = getSelected(nextState)
+    const selectedDataState: Slice<T> = getSelected(nextDataState)
 
     const update = (updateSelected: UpdateCb<Slice<T>>) => (
       updateFn((draft) => updateSelected(getSelected(draft as G)))
     )
 
     return [
-      slicedNextState,
+      selectedDataState,
       {
+      /**
+       * @description 
+       * Use .update() to make mutations, like with immer, to your data structure. 
+       * @example 
+       * const [record, { update }] useData(data)
+       * 
+       * update((record) => {
+       *   record.attributes.status = 'successful'
+       *   record.attributes.info = 'some value...'
+       * })
+      */
         update,
-        select: createReturnedTuple<Slice<T>>(slicedNextState, update)
+      /**
+       * @description 
+       * Narrow down the state and updater by using .select()
+       * @example 
+       * const [record, { select }] useData(data)
+       * 
+       * const [attributes, { update }] = select(record => record.atributes)
+      */
+        select: createReturnedTuple<Slice<T>>(selectedDataState, update)
       }
     ] as const
   }

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -12,9 +12,9 @@ type UpdateCb<G> = (args: Draft<G>) => G|void|undefined
 function createReturnedTuple<G> (nextState: G, updateFn: (cb: UpdateCb<G>) => void) {
   return <T extends (slice: G) => any>(getSelected: T) => {
     const slicedNextState: Slice<T> = getSelected(nextState)
-    
+
     const update = (updateSelected: UpdateCb<Slice<T>>) => (
-      updateFn((state) => updateSelected(getSelected(state as G)))
+      updateFn((proxy) => updateSelected(getSelected(proxy as G)))
     )
 
     return [

--- a/src/useData.ts
+++ b/src/useData.ts
@@ -4,12 +4,13 @@ import produce, { Draft } from 'immer'
 function createSelect (nextState: any, updater: any) {
   return (selector: any) => {
     const slicedNextState = selector(nextState)
+    const slicedUpdater = (cb: any) => updater((state: any) => cb(selector(state)))
 
     return [
       slicedNextState,
       {
-        update: (cb: any) => updater((state: any) => cb(selector(state))),
-        select: createSelect(slicedNextState, (cb: any) => updater((state: any) => cb(selector(state)) )
+        update: slicedUpdater,
+        select: createSelect(slicedNextState, slicedUpdater)
       }
     ]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
 
-
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -18,10 +17,13 @@
 
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+ 
+    "pretty": true
   },
   "include": [
-    "src"
+    "src", 
+    "examples"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Adjusted the interface to be more simple and consistent. The sliceEntity method was replaced with select which now has the same return signature as useData(). The draft method was renamed to update and all other methods have been removed.